### PR TITLE
Add basic HTML generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 hackpack.pdf
+hackpack.html

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CU Cyber Hackpack
 =================
 
-In this repository are the markdown sources to the hackpack used by CU Cyber in general and at competitions. An up-to-date build of the hackpack is available at [https://cucyber.net/documents/hackpack.pdf](https://cucyber.net/documents/hackpack.pdf).
+In this repository are the markdown sources to the hackpack used by CU Cyber in general and at competitions. An up-to-date build of the hackpack is available in HTML at [https://cucyber.net/documents/hackpack.html](https://cucyber.net/documents/hackpack.html) and in PDF at [https://cucyber.net/documents/hackpack.pdf](https://cucyber.net/documents/hackpack.pdf).
 
 
 ## Dependencies

--- a/backups/rsnapshot.md
+++ b/backups/rsnapshot.md
@@ -6,7 +6,7 @@
 rnapshot is a utility to create incremental snapshot backups using rsync. It has minimal dependencies and should work even on very old Linux distributions.
 
 
-### Dependencies
+#### Dependencies
 
 * perl
 * rsync

--- a/backups/simple.md
+++ b/backups/simple.md
@@ -6,7 +6,7 @@
 To create simple archive backups, use the tar command. These backups should be created as the initial backups during the beginning period of the competition.
 
 
-### Dependencies
+#### Dependencies
 
 * tar
 

--- a/cyber.html
+++ b/cyber.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html$if(lang)$ lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
+<head>
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+$for(author-meta)$
+  <meta name="author" content="$author-meta$">
+$endfor$
+$if(date-meta)$
+  <meta name="dcterms.date" content="$date-meta$">
+$endif$
+$if(keywords)$
+  <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$">
+$endif$
+  <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
+  <style type="text/css">code{white-space: pre;}</style>
+$if(quotes)$
+  <style type="text/css">q { quotes: "“" "”" "‘" "’"; }</style>
+$endif$
+$if(highlighting-css)$
+  <style type="text/css">
+$highlighting-css$
+  </style>
+$endif$
+$for(css)$
+  <link rel="stylesheet" href="$css$">
+$endfor$
+$if(math)$
+  $math$
+$endif$
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
+$for(header-includes)$
+  $header-includes$
+$endfor$
+</head>
+<body>
+$for(include-before)$
+$include-before$
+$endfor$
+$if(title)$
+<header>
+<h1 class="title">$title$</h1>
+$if(subtitle)$
+<p class="subtitle">$subtitle$</p>
+$endif$
+$for(author)$
+<p class="author">$author$</p>
+$endfor$
+$if(date)$
+<p class="date">$date$</p>
+$endif$
+</header>
+$endif$
+$if(toc)$
+<nav id="$idprefix$TOC">
+$toc$
+</nav>
+$endif$
+$body$
+$for(include-after)$
+$include-after$
+$endfor$
+</body>
+</html>

--- a/cyber.html
+++ b/cyber.html
@@ -62,12 +62,20 @@
                 word-wrap: break-word;
             }
 
-            @media (min-width: 767px) {
+            @media (min-width: 768px) {
                 *[id]:before {
                     display: block;
                     content: " ";
                     margin-top: -141px;
                     height: 141px;
+                    visibility: hidden;
+                }
+
+                #TOC:before {
+                    display: block;
+                    content: " ";
+                    margin-top: -221px;
+                    height: 221px;
                     visibility: hidden;
                 }
             }

--- a/cyber.html
+++ b/cyber.html
@@ -126,7 +126,7 @@ $highlighting-css$
                                 <div class="dropdown-menu">
                                     <ul>
                                         <li><a href="/resources.html">Presentations</a></li>
-                                        <li><a href="/hackpack.html">Hackpack</a></li>
+                                        <li><a href="/documents/hackpack.html">Hackpack</a></li>
                                         <li><a href="https://clemson.collegiatelink.net/organization/cucyber">TigerQuest</a></li>
                                     </ul>
                                 </div>
@@ -154,6 +154,7 @@ $highlighting-css$
                                         Home
                                     </a>
                                 </li>
+                                <li>Documents</li>
                                 <li class="active">Cyber Defense Hackpack</li>
                             </ol>
                         </div>

--- a/cyber.html
+++ b/cyber.html
@@ -113,7 +113,7 @@ $highlighting-css$
                 <!-- main menu -->
                 <nav class="collapse navbar-collapse navbar-right" role="navigation">
                     <div class="main-menu">
-                        <ul class="nav navbar-nav navbar-right">
+                        <ul class="flat nav navbar-nav navbar-right">
                             <li>
                                 <a href="/index.html">Home</a>
                             </li>
@@ -124,7 +124,7 @@ $highlighting-css$
                             <li class="dropdown">
                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Useful Resources <span class="caret"></span></a>
                                 <div class="dropdown-menu">
-                                    <ul>
+                                    <ul class="flat">
                                         <li><a href="/resources.html">Presentations</a></li>
                                         <li><a href="/documents/hackpack.html">Hackpack</a></li>
                                         <li><a href="https://clemson.collegiatelink.net/organization/cucyber">TigerQuest</a></li>

--- a/cyber.html
+++ b/cyber.html
@@ -102,17 +102,15 @@
             if (window.location.hostname != 'localhost' && window.location.hostname != '127.0.0.1' && window.location.protocol != 'https:')
                 window.location.protocol = 'https';
         </script>
-        
-        <!-- JavaScript to handle changing the button text of the show/hide TOC button. -->
+
+        <!-- TOC Button JavaScript -->
         <script type="text/javascript">
-            $$(document).ready(function(){
-                $$("#TOC-toggle").click(function() {
-                    if($$(this).text() == "Show"){
-                        $$(this).text("Hide");
-                    }
-                    else {
-                        $$(this).text("Show");
-                    }
+            $$(document).ready(function() {
+                $$('#top > .btn').click(function() {
+                    if ($$(this).text() === 'Show')
+                        $$(this).text('Hide');
+                    else
+                        $$(this).text('Show');
                 });
             });
         </script>
@@ -218,7 +216,7 @@
                         <p>You can download a PDF of this hackpack <a href="/documents/hackpack.pdf">here</a> and find the Markdown sources of this hackpack on <a href="https://github.com/CUCyber/Hackpack">GitHub</a>.</p>
 
                         $if(toc)$
-                        <h1 id="top">Table of Contents <button data-toggle="collapse" data-target="#TOC" class="btn" id="TOC-toggle">Show</button></h1>
+                        <h1 id="top">Table of Contents <button data-toggle="collapse" data-target="#TOC" class="btn">Show</button></h1>
 
                         <nav id="$idprefix$TOC" class="collapse">
                             $toc$

--- a/cyber.html
+++ b/cyber.html
@@ -56,9 +56,26 @@
 
         <!-- Pandoc Styling
         ================================================== -->
-        <style type="text/css">code{ white-space: pre-wrap; word-wrap: break-word; }</style>
+        <style type="text/css">
+            code {
+                white-space: pre-wrap;
+                word-wrap: break-word;
+            }
+
+            *[id]:before {
+                display: block;
+                content: " ";
+                margin-top: -141px;
+                height: 141px;
+                visibility: hidden;
+            }
+        </style>
         $if(quotes)$
-        <style type="text/css">q { quotes: "“" "”" "‘" "’"; }</style>
+        <style type="text/css">
+            q {
+                quotes: "“" "”" "‘" "’";
+            }
+        </style>
         $endif$
         $if(highlighting-css)$
         <style type="text/css">

--- a/cyber.html
+++ b/cyber.html
@@ -102,6 +102,20 @@
             if (window.location.hostname != 'localhost' && window.location.hostname != '127.0.0.1' && window.location.protocol != 'https:')
                 window.location.protocol = 'https';
         </script>
+        
+        <!-- JavaScript to handle changing the button text of the show/hide TOC button. -->
+        <script type="text/javascript">
+            $$(document).ready(function(){
+                $$("#TOC-toggle").click(function() {
+                    if($$(this).text() == "Show"){
+                        $$(this).text("Hide");
+                    }
+                    else {
+                        $$(this).text("Show");
+                    }
+                });
+            });
+        </script>
     </head>
     <body>
         <!--
@@ -204,9 +218,9 @@
                         <p>You can download a PDF of this hackpack <a href="/documents/hackpack.pdf">here</a> and find the Markdown sources of this hackpack on <a href="https://github.com/CUCyber/Hackpack">GitHub</a>.</p>
 
                         $if(toc)$
-                        <h1 id="top">Table of Contents</h1>
+                        <h1 id="top">Table of Contents <button data-toggle="collapse" data-target="#TOC" class="btn" id="TOC-toggle">Show</button></h1>
 
-                        <nav id="$idprefix$TOC">
+                        <nav id="$idprefix$TOC" class="collapse">
                             $toc$
                         </nav>
                         $endif$

--- a/cyber.html
+++ b/cyber.html
@@ -62,28 +62,12 @@
                 word-wrap: break-word;
             }
 
-            #TOC:before {
-                display: block;
-                content: " ";
-                margin-top: -100px;
-                height: 100px;
-                visibility: hidden;
-            }
-
             @media (min-width: 768px) {
                 *[id]:before {
                     display: block;
                     content: " ";
                     margin-top: -141px;
                     height: 141px;
-                    visibility: hidden;
-                }
-
-                #TOC:before {
-                    display: block;
-                    content: " ";
-                    margin-top: -221px;
-                    height: 221px;
                     visibility: hidden;
                 }
             }
@@ -97,7 +81,7 @@
         $endif$
         $if(highlighting-css)$
         <style type="text/css">
-$highlighting-css$
+            $highlighting-css$
         </style>
         $endif$
         $for(css)$
@@ -201,34 +185,36 @@ $highlighting-css$
         <section class="single-post">
             <div class="container">
                 <div class="row">
-                    <p>You can download a PDF of this hackpack <a href="/documents/hackpack.pdf">here</a> and find the Markdown sources of this hackpack on <a href="https://github.com/CUCyber/Hackpack">GitHub</a>.</p>
-
-                    $for(include-before)$
-                    $include-before$
-                    $endfor$
-                    $if(title)$
-                    <header>
-                        <h1 class="title">$title$</h1>
-                        $if(subtitle)$
-                        <p class="subtitle">$subtitle$</p>
-                        $endif$
-                        $for(author)$
-                        <p class="author">$author$</p>
+                    <div class="col-md-12">
+                        $for(include-before)$
+                        $include-before$
                         $endfor$
-                        $if(date)$
-                        <p class="date">$date$</p>
+                        $if(title)$
+                        <header>
+                            <h1>$title$</h1>
+                            $if(subtitle)$
+                            <p class="subtitle">$subtitle$</p>
+                            $endif$
+                            $if(date)$
+                            <p class="date">$date$</p>
+                            $endif$
+                        </header>
                         $endif$
-                    </header>
-                    $endif$
-                    $if(toc)$
-                    <nav id="$idprefix$TOC">
-                        $toc$
-                    </nav>
-                    $endif$
-                    $body$
-                    $for(include-after)$
-                    $include-after$
-                    $endfor$
+
+                        <p>You can download a PDF of this hackpack <a href="/documents/hackpack.pdf">here</a> and find the Markdown sources of this hackpack on <a href="https://github.com/CUCyber/Hackpack">GitHub</a>.</p>
+
+                        $if(toc)$
+                        <h1 id="top">Table of Contents</h1>
+
+                        <nav id="$idprefix$TOC">
+                            $toc$
+                        </nav>
+                        $endif$
+                        $body$
+                        $for(include-after)$
+                        $include-after$
+                        $endfor$
+                    </div>
                 </div>
             </div>
         </section>

--- a/cyber.html
+++ b/cyber.html
@@ -56,7 +56,7 @@
 
         <!-- Pandoc Styling
         ================================================== -->
-        <style type="text/css">code{white-space: pre-wrap;}</style>
+        <style type="text/css">code{ white-space: pre-wrap; word-wrap: break-word; }</style>
         $if(quotes)$
         <style type="text/css">q { quotes: "“" "”" "‘" "’"; }</style>
         $endif$

--- a/cyber.html
+++ b/cyber.html
@@ -62,12 +62,14 @@
                 word-wrap: break-word;
             }
 
-            *[id]:before {
-                display: block;
-                content: " ";
-                margin-top: -141px;
-                height: 141px;
-                visibility: hidden;
+            @media (min-width: 767px) {
+                *[id]:before {
+                    display: block;
+                    content: " ";
+                    margin-top: -141px;
+                    height: 141px;
+                    visibility: hidden;
+                }
             }
         </style>
         $if(quotes)$

--- a/cyber.html
+++ b/cyber.html
@@ -56,7 +56,7 @@
 
         <!-- Pandoc Styling
         ================================================== -->
-        <style type="text/css">code{white-space: pre;}</style>
+        <style type="text/css">code{white-space: pre-wrap;}</style>
         $if(quotes)$
         <style type="text/css">q { quotes: "“" "”" "‘" "’"; }</style>
         $endif$

--- a/cyber.html
+++ b/cyber.html
@@ -225,7 +225,7 @@
         <footer id="footer">
             <div class="container">
                 <div class="col-md-8">
-                    <p class="copyright">Copyright: <span>2017</span> . Design and Developed by <a href="http://www.Themefisher.com">Themefisher</a></p>
+                    <p class="copyright">Copyright: <span>2017</span> CU Cyber &lt;cyber@clemson.edu&gt;. Design and Developed by <a href="http://www.Themefisher.com">Themefisher</a></p>
                 </div>
             </div>
         </footer> <!-- /#footer -->

--- a/cyber.html
+++ b/cyber.html
@@ -1,67 +1,211 @@
 <!DOCTYPE html>
-<html$if(lang)$ lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
-<head>
-  <meta charset="utf-8">
-  <meta name="generator" content="pandoc">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-$for(author-meta)$
-  <meta name="author" content="$author-meta$">
-$endfor$
-$if(date-meta)$
-  <meta name="dcterms.date" content="$date-meta$">
-$endif$
-$if(keywords)$
-  <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$">
-$endif$
-  <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
-  <style type="text/css">code{white-space: pre;}</style>
-$if(quotes)$
-  <style type="text/css">q { quotes: "“" "”" "‘" "’"; }</style>
-$endif$
-$if(highlighting-css)$
-  <style type="text/css">
+<html$if(lang)$ lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$ class="no-js">
+    <head>
+        <!-- Basic Page Needs
+        ================================================== -->
+        <meta charset="utf-8">
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <link rel="icon" type="image/png" href="/images/shield-small.png">
+        <title>CU Cyber - Hackpack</title>
+        <link rel="shortcut icon" href="/images/shield-small.png">
+        <meta name="description" content="">
+        <meta name="keywords" content="">
+        <meta name="author" content="">
+        <!-- Mobile Specific Metas
+        ================================================== -->
+        <meta name="format-detection" content="telephone=no">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <!-- Template CSS Files
+        ================================================== -->
+        <!-- Twitter Bootstrs CSS -->
+        <link rel="stylesheet" href="/css/bootstrap.min.css">
+        <!-- Ionicons Fonts Css -->
+        <link rel="stylesheet" href="/css/ionicons.min.css">
+        <!-- animate css -->
+        <link rel="stylesheet" href="/css/animate.css">
+        <!-- Hero area slider css-->
+        <link rel="stylesheet" href="/css/slider.css">
+        <!-- owl craousel css -->
+        <link rel="stylesheet" href="/css/owl.carousel.css">
+        <link rel="stylesheet" href="/css/owl.theme.css">
+        <link rel="stylesheet" href="/css/jquery.fancybox.css">
+        <!-- template main css file -->
+        <link rel="stylesheet" href="/css/main.css">
+        <!-- responsive css -->
+        <link rel="stylesheet" href="/css/responsive.css">
+
+        <!-- Template Javascript Files
+        ================================================== -->
+        <!-- modernizr js -->
+        <script src="/js/vendor/modernizr-2.6.2.min.js"></script>
+        <!-- jquery -->
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+        <!-- owl carouserl js -->
+        <script src="/js/owl.carousel.min.js"></script>
+        <!-- bootstrap js -->
+
+        <script src="/js/bootstrap.min.js"></script>
+        <!-- wow js -->
+        <script src="/js/wow.min.js"></script>
+        <!-- slider js -->
+        <script src="/js/slider.js"></script>
+        <script src="/js/jquery.fancybox.js"></script>
+        <!-- template main js -->
+        <script src="/js/main.js"></script>
+
+        <!-- Pandoc Styling
+        ================================================== -->
+        <style type="text/css">code{white-space: pre;}</style>
+        $if(quotes)$
+        <style type="text/css">q { quotes: "“" "”" "‘" "’"; }</style>
+        $endif$
+        $if(highlighting-css)$
+        <style type="text/css">
 $highlighting-css$
-  </style>
-$endif$
-$for(css)$
-  <link rel="stylesheet" href="$css$">
-$endfor$
-$if(math)$
-  $math$
-$endif$
-  <!--[if lt IE 9]>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
-  <![endif]-->
-$for(header-includes)$
-  $header-includes$
-$endfor$
-</head>
-<body>
-$for(include-before)$
-$include-before$
-$endfor$
-$if(title)$
-<header>
-<h1 class="title">$title$</h1>
-$if(subtitle)$
-<p class="subtitle">$subtitle$</p>
-$endif$
-$for(author)$
-<p class="author">$author$</p>
-$endfor$
-$if(date)$
-<p class="date">$date$</p>
-$endif$
-</header>
-$endif$
-$if(toc)$
-<nav id="$idprefix$TOC">
-$toc$
-</nav>
-$endif$
-$body$
-$for(include-after)$
-$include-after$
-$endfor$
-</body>
+        </style>
+        $endif$
+        $for(css)$
+        <link rel="stylesheet" href="$css$">
+        $endfor$
+        $if(math)$
+        $math$
+        $endif$
+        <!--[if lt IE 9]>
+            <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+        <![endif]-->
+        $for(header-includes)$
+        $header-includes$
+        $endfor$
+
+        <!-- HTTPS JavaScript Redirect -->
+        <script>
+            if (window.location.hostname != 'localhost' && window.location.hostname != '127.0.0.1' && window.location.protocol != 'https:')
+                window.location.protocol = 'https';
+        </script>
+    </head>
+    <body>
+        <!--
+        ==================================================
+        Header Section Start
+        ================================================== -->
+        <header id="top-bar" class="navbar-fixed-top animated-header">
+            <div class="container">
+                <div class="navbar-header">
+                    <!-- responsive nav button -->
+                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                    <!-- /responsive nav button -->
+                    <!-- logo -->
+                    <div class="navbar-brand">
+                        <a href="/index.html" class="stop-theme">
+                            <img src="/images/shield-small.png" alt="CU Cyber">
+                            CU Cyber
+                        </a>
+                    </div>
+                    <!-- /logo -->
+
+                </div>
+                <!-- main menu -->
+                <nav class="collapse navbar-collapse navbar-right" role="navigation">
+                    <div class="main-menu">
+                        <ul class="nav navbar-nav navbar-right">
+                            <li>
+                                <a href="/index.html">Home</a>
+                            </li>
+                            <li><a href="/about.html">About</a></li>
+                            <li><a href="/events.html">Events</a></li>
+                            <li><a href="/contact.html">Contact us</a></li>
+
+                            <li class="dropdown">
+                                <a href="#" class="dropdown-toggle" data-toggle="dropdown">Useful Resources <span class="caret"></span></a>
+                                <div class="dropdown-menu">
+                                    <ul>
+                                        <li><a href="/resources.html">Presentations</a></li>
+                                        <li><a href="/hackpack.html">Hackpack</a></li>
+                                        <li><a href="https://clemson.collegiatelink.net/organization/cucyber">TigerQuest</a></li>
+                                    </ul>
+                                </div>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+                <!-- /main nav -->
+            </div>
+        </header>
+        <!--
+        ==================================================
+            Global Page Section Start
+        ================================================== -->
+        <section class="global-page-header">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="block">
+                            <h2>Hackpack</h2>
+                            <ol class="breadcrumb">
+                                <li>
+                                    <a href="/index.html">
+                                        <i class="ion-ios-home"></i>
+                                        Home
+                                    </a>
+                                </li>
+                                <li class="active">Cyber Defense Hackpack</li>
+                            </ol>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="single-post">
+            <div class="container">
+                <div class="row">
+                    <p>You can download a PDF of this hackpack <a href="/hackpack.pdf">here</a> and find the Markdown sources of this hackpack on <a href="https://github.com/CUCyber/Hackpack">GitHub</a>.</p>
+
+                    $for(include-before)$
+                    $include-before$
+                    $endfor$
+                    $if(title)$
+                    <header>
+                        <h1 class="title">$title$</h1>
+                        $if(subtitle)$
+                        <p class="subtitle">$subtitle$</p>
+                        $endif$
+                        $for(author)$
+                        <p class="author">$author$</p>
+                        $endfor$
+                        $if(date)$
+                        <p class="date">$date$</p>
+                        $endif$
+                    </header>
+                    $endif$
+                    $if(toc)$
+                    <nav id="$idprefix$TOC">
+                        $toc$
+                    </nav>
+                    $endif$
+                    $body$
+                    $for(include-after)$
+                    $include-after$
+                    $endfor$
+                </div>
+            </div>
+        </section>
+        <!--
+        ==================================================
+        Footer Section Start
+        ================================================== -->
+        <footer id="footer">
+            <div class="container">
+                <div class="col-md-8">
+                    <p class="copyright">Copyright: <span>2017</span> . Design and Developed by <a href="http://www.Themefisher.com">Themefisher</a></p>
+                </div>
+            </div>
+        </footer> <!-- /#footer -->
+    </body>
 </html>

--- a/cyber.html
+++ b/cyber.html
@@ -62,6 +62,14 @@
                 word-wrap: break-word;
             }
 
+            #TOC:before {
+                display: block;
+                content: " ";
+                margin-top: -100px;
+                height: 100px;
+                visibility: hidden;
+            }
+
             @media (min-width: 768px) {
                 *[id]:before {
                     display: block;

--- a/cyber.html
+++ b/cyber.html
@@ -166,7 +166,7 @@ $highlighting-css$
         <section class="single-post">
             <div class="container">
                 <div class="row">
-                    <p>You can download a PDF of this hackpack <a href="/hackpack.pdf">here</a> and find the Markdown sources of this hackpack on <a href="https://github.com/CUCyber/Hackpack">GitHub</a>.</p>
+                    <p>You can download a PDF of this hackpack <a href="/documents/hackpack.pdf">here</a> and find the Markdown sources of this hackpack on <a href="https://github.com/CUCyber/Hackpack">GitHub</a>.</p>
 
                     $for(include-before)$
                     $include-before$

--- a/html.py
+++ b/html.py
@@ -7,8 +7,8 @@ from pandocfilters import walk, Header, Link, Para, Str
 
 # record how many headers deep we are
 depth = 0
-# create node that is a block paragraph with a link that says 'Jump to Top' and hrefs '#TOC'
-jump = Para([Link(['', [], []], [Str('Jump to Top')], ('#TOC', 'top'))])
+# create node that is a block paragraph with a link that says 'Jump to Top' and hrefs '#top'
+jump = Para([Link(['', [], []], [Str('Jump to Top')], ('#top', 'top'))])
 
 
 # add jumps before headers of the document

--- a/html.py
+++ b/html.py
@@ -5,33 +5,46 @@ import sys
 from pandocfilters import walk, Header, Link, Para, Str
 
 
+# record how many headers deep we are
 depth = 0
+# create node that is a block paragraph with a link that says 'Jump to Top' and hrefs '#'
 jump = Para([Link(['', [], []], [Str('Jump to Top')], ('#', 'top'))])
 
 
+# add jumps before headers of the document
 def add_to_headers(key, val, fmt, meta):
     global depth
 
+    # when we are at a header node
     if key == 'Header':
+        # get details of header
         lvl, attr, inline = val
 
+        # if we are at the first header of a larger section
         if lvl > depth:
+            # record the depth and do not place a jump
             depth += 1
             return
         elif lvl < depth:
+            # bring depth down to level
             depth = lvl
 
+        # if the header is noteworthy, put a jump before it
         if lvl <= 3:
             return [jump, Header(lvl, attr, inline)]
 
 
+# add jumps in all necessary places in the document
 def jump_to_top(doc, fmt):
+    # add jumps throughout the document
     doc = walk(doc, add_to_headers, fmt, doc['meta'] if 'meta' in doc else {})
 
+    # add a jump at the bottom of the document
     doc['blocks'].append(jump)
 
     return doc
 
 
 if __name__ == '__main__':
+    # read JSON in, parse it with an optional format argument, and write JSON out
     json.dump(jump_to_top(json.load(sys.stdin), sys.argv[1] if len(sys.argv) > 1 else ''), sys.stdout)

--- a/html.py
+++ b/html.py
@@ -7,8 +7,8 @@ from pandocfilters import walk, Header, Link, Para, Str
 
 # record how many headers deep we are
 depth = 0
-# create node that is a block paragraph with a link that says 'Jump to Top' and hrefs '#'
-jump = Para([Link(['', [], []], [Str('Jump to Top')], ('#', 'top'))])
+# create node that is a block paragraph with a link that says 'Jump to Top' and hrefs '#TOC'
+jump = Para([Link(['', [], []], [Str('Jump to Top')], ('#TOC', 'top'))])
 
 
 # add jumps before headers of the document

--- a/html.py
+++ b/html.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+from pandocfilters import walk, Header, Link, Para, Str
+
+
+depth = 0
+jump = Para([Link(['', [], []], [Str('Jump to Top')], ('#', 'top'))])
+
+
+def add_to_headers(key, val, fmt, meta):
+    global depth
+
+    if key == 'Header':
+        lvl, attr, inline = val
+
+        if lvl > depth:
+            depth += 1
+            return
+        elif lvl < depth:
+            depth = lvl
+
+        if lvl <= 3:
+            return [jump, Header(lvl, attr, inline)]
+
+
+def jump_to_top(doc, fmt):
+    doc = walk(doc, add_to_headers, fmt, doc['meta'] if 'meta' in doc else {})
+
+    doc['blocks'].append(jump)
+
+    return doc
+
+
+if __name__ == "__main__":
+    json.dump(jump_to_top(json.load(sys.stdin), sys.argv[1] if len(sys.argv) > 1 else ''), sys.stdout)

--- a/html.py
+++ b/html.py
@@ -33,5 +33,5 @@ def jump_to_top(doc, fmt):
     return doc
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     json.dump(jump_to_top(json.load(sys.stdin), sys.argv[1] if len(sys.argv) > 1 else ''), sys.stdout)

--- a/makefile
+++ b/makefile
@@ -1,14 +1,20 @@
 SHELL=/bin/bash
 
-OUTFILE=hackpack.html
+OUTFILE=hackpack.pdf
 
-FILTER=./html.py
-TEMPLATE=./cyber.html
+TEMPLATE=./cyber.latex
+
+OUTFILE_HTML=hackpack.html
+
+FILTER_HTML=./html.py
+TEMPLATE_HTML=./cyber.html
+
 HIGHLIGHT_STYLE=tango
 
 FIND=./find.py
 
 WEBSITE=../website
+DIRECTORY=documents/
 
 SOURCES!="$(FIND)" -e 'LICENSE.md' -e 'README.md' -f general -f checklists -l appendix -g index.md .
 
@@ -17,18 +23,21 @@ all: $(OUTFILE)
 open: $(OUTFILE)
 	xdg-open "$(OUTFILE)" &>/dev/null & disown
 
-update: $(WEBSITE)/$(OUTFILE)
+update: $(WEBSITE)/$(DIRECTORY)$(OUTFILE)
 
 clean:
 	rm -f "$(OUTFILE)"
 
 $(OUTFILE): $(SOURCES)
-	pandoc --filter="$(FILTER)" --template="$(TEMPLATE)" --highlight-style="${HIGHLIGHT_STYLE}" --standalone --toc --output "$(OUTFILE)" $(SOURCES)
+	pandoc --template="$(TEMPLATE)" --highlight-style="${HIGHLIGHT_STYLE}" --standalone --toc --output "$(OUTFILE)" $(SOURCES)
 
-$(WEBSITE)/$(OUTFILE): $(OUTFILE)
-	cp $(OUTFILE) $(WEBSITE)/documents/
+$(OUTFILE_HTML): $(SOURCES)
+	pandoc --filter="$(FILTER_HTML)" --template="$(TEMPLATE_HTML)" --highlight-style="${HIGHLIGHT_STYLE}" --standalone --toc --output "$(OUTFILE_HTML)" $(SOURCES)
 
-	git -C "$(WEBSITE)" add documents/"$(OUTFILE)"
+$(WEBSITE)/$(DIRECTORY)$(OUTFILE): $(OUTFILE) $(OUTFILE_HTML)
+	cp "$(OUTFILE)" "$(OUTFILE_HTML)" "$(WEBSITE)/$(DIRECTORY)"
+
+	git -C "$(WEBSITE)" add "$(DIRECTORY)$(OUTFILE)" "$(DIRECTORY)$(OUTFILE_HTML)"
 	git -C "$(WEBSITE)" commit -m "update hackpack"
 	git -C "$(WEBSITE)" push
 

--- a/makefile
+++ b/makefile
@@ -24,6 +24,9 @@ open: $(OUTFILE)
 	xdg-open "$(OUTFILE)" &>/dev/null & disown
 
 update: $(WEBSITE)/$(DIRECTORY)$(OUTFILE) $(WEBSITE)/$(DIRECTORY)$(OUTFILE_HTML)
+	git -C "$(WEBSITE)" add "$(DIRECTORY)$(OUTFILE)" "$(DIRECTORY)$(OUTFILE_HTML)"
+	git -C "$(WEBSITE)" commit -m "update hackpack"
+	git -C "$(WEBSITE)" push
 
 clean:
 	rm -f "$(OUTFILE)" "$(OUTFILE_HTML)"
@@ -34,11 +37,10 @@ $(OUTFILE): $(SOURCES)
 $(OUTFILE_HTML): $(SOURCES)
 	pandoc --filter="$(FILTER_HTML)" --template="$(TEMPLATE_HTML)" --highlight-style="${HIGHLIGHT_STYLE}" --standalone --toc --output "$(OUTFILE_HTML)" $(SOURCES)
 
-$(WEBSITE)/$(DIRECTORY)$(OUTFILE): $(OUTFILE) $(OUTFILE_HTML)
-	cp "$(OUTFILE)" "$(OUTFILE_HTML)" "$(WEBSITE)/$(DIRECTORY)"
+$(WEBSITE)/$(DIRECTORY)$(OUTFILE): $(OUTFILE)
+	cp "$(OUTFILE)" "$(WEBSITE)/$(DIRECTORY)"
 
-	git -C "$(WEBSITE)" add "$(DIRECTORY)$(OUTFILE)" "$(DIRECTORY)$(OUTFILE_HTML)"
-	git -C "$(WEBSITE)" commit -m "update hackpack"
-	git -C "$(WEBSITE)" push
+$(WEBSITE)/$(DIRECTORY)$(OUTFILE_HTML): $(OUTFILE_HTML)
+	cp "$(OUTFILE_HTML)" "$(WEBSITE)/$(DIRECTORY)"
 
 .PHONY: all open update clean

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ all: $(OUTFILE)
 open: $(OUTFILE)
 	xdg-open "$(OUTFILE)" &>/dev/null & disown
 
-update: $(WEBSITE)/$(DIRECTORY)$(OUTFILE)
+update: $(WEBSITE)/$(DIRECTORY)$(OUTFILE) $(WEBSITE)/$(DIRECTORY)$(OUTFILE_HTML)
 
 clean:
 	rm -f "$(OUTFILE)"

--- a/makefile
+++ b/makefile
@@ -1,8 +1,9 @@
 SHELL=/bin/bash
 
-OUTFILE=hackpack.pdf
+OUTFILE=hackpack.html
 
-TEMPLATE=./cyber.latex
+FILTER=./html.py
+TEMPLATE=./cyber.html
 HIGHLIGHT_STYLE=tango
 
 FIND=./find.py
@@ -22,7 +23,7 @@ clean:
 	rm -f "$(OUTFILE)"
 
 $(OUTFILE): $(SOURCES)
-	pandoc --template="$(TEMPLATE)" --highlight-style="${HIGHLIGHT_STYLE}" --standalone --toc --output "$(OUTFILE)" $(SOURCES)
+	pandoc --filter="$(FILTER)" --template="$(TEMPLATE)" --highlight-style="${HIGHLIGHT_STYLE}" --standalone --toc --output "$(OUTFILE)" $(SOURCES)
 
 $(WEBSITE)/$(OUTFILE): $(OUTFILE)
 	cp $(OUTFILE) $(WEBSITE)/documents/

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ open: $(OUTFILE)
 update: $(WEBSITE)/$(DIRECTORY)$(OUTFILE) $(WEBSITE)/$(DIRECTORY)$(OUTFILE_HTML)
 
 clean:
-	rm -f "$(OUTFILE)"
+	rm -f "$(OUTFILE)" "$(OUTFILE_HTML)"
 
 $(OUTFILE): $(SOURCES)
 	pandoc --template="$(TEMPLATE)" --highlight-style="${HIGHLIGHT_STYLE}" --standalone --toc --output "$(OUTFILE)" $(SOURCES)

--- a/services/tomcat.md
+++ b/services/tomcat.md
@@ -39,7 +39,7 @@ Apache Tomcat is a web server designed to serve Java Server Page (JSP) web appli
 * Configure Logging
 	- Ensure the following lines are in logging.properties `handlers=org.apache.juli.FileHandler, java.util.logging.ConsoleHandler`
 	- Ensure the following lines are in logging.properties `org.apache.juli.FileHandler.level=FINEST`
-	- Ensure that className is set to org.apache.catalina.valves.FastCommonAccessLogValve in `$CATALINA_BASE/<app name>/META-INF/context.xml`
+	- Ensure that `className` is set to `org.apache.catalina.valves.FastCommonAccessLogValve` in `$CATALINA_BASE/<app name>/META-INF/context.xml`
 	- Ensure that directory is set to `$CATALINA_HOME/logs` |in `$CATALINA_BASE/<app name>/META-INF/context.xml`
 	- Ensure that pattern is set to `"%t % U %a %A %m %p %q %s"` in `$CATALINA_BASE/<app name>/META-INF/context.xml`
 * Prevent unexpected code execution


### PR DESCRIPTION
Do not merge this yet. I'm just putting this here for tracking.

We'll need to fix the backups and restoration section to have proper header leveling. Other than that, we'll just need to fix up the styling with the website and put both targets in the makefile (defaulting to PDF obviously).

- [x] Fix Backups and Restoration header leveling
- [x] Add website styling
- [x] Have the makefile support both HTML and PDF targets
- [x] Add links at the top to both the generated PDF and to the GitHub page
- [x] Add a link to the HTML in the readme
- [x] Fix unnumbered list styling on website (CUCyber/cucyber.github.io#7)
- [x] Update the menu bar to point to this page instead of the GitHub page (CUCyber/cucyber.github.io#7)