### PR TITLE
updated /etc/named.conf settings

### DIFF
--- a/services/bind.md
+++ b/services/bind.md
@@ -46,6 +46,9 @@ options {
 #    8.8.8.8;
 #    8.8.4.4;
 #};
+
+#include the zone settings file
+include "/var/named/example.com.conf";
 ```
 
 


### PR DESCRIPTION
Without the added line the zone information will not be loaded, causing queries to not properly resolve.